### PR TITLE
[global-scheduler][PR-1] Skeleton + config schema + minimal health server

### DIFF
--- a/tests/global_scheduler/test_config.py
+++ b/tests/global_scheduler/test_config.py
@@ -1,0 +1,80 @@
+import textwrap
+
+import pytest
+
+from vllm_omni.global_scheduler.config import load_config
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+
+def test_load_config_success(tmp_path):
+    config_path = tmp_path / "scheduler.yaml"
+    config_path.write_text(
+        textwrap.dedent(
+            """
+            server:
+              host: 0.0.0.0
+              port: 8089
+            scheduler:
+              type: baseline_sp1
+            instances:
+              - id: worker-0
+                endpoint: http://127.0.0.1:9001
+                sp_size: 1
+                max_concurrency: 2
+              - id: worker-1
+                endpoint: http://127.0.0.1:9002
+                sp_size: 1
+                max_concurrency: 2
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    config = load_config(config_path)
+
+    assert config.server.port == 8089
+    assert config.scheduler.type == "baseline_sp1"
+    assert len(config.instances) == 2
+
+
+def test_load_config_duplicate_instance_id(tmp_path):
+    config_path = tmp_path / "scheduler.yaml"
+    config_path.write_text(
+        textwrap.dedent(
+            """
+            instances:
+              - id: worker-0
+                endpoint: http://127.0.0.1:9001
+                sp_size: 1
+                max_concurrency: 2
+              - id: worker-0
+                endpoint: http://127.0.0.1:9002
+                sp_size: 1
+                max_concurrency: 2
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="globally unique"):
+        load_config(config_path)
+
+
+def test_load_config_invalid_endpoint(tmp_path):
+    config_path = tmp_path / "scheduler.yaml"
+    config_path.write_text(
+        textwrap.dedent(
+            """
+            instances:
+              - id: worker-0
+                endpoint: https://127.0.0.1:9001
+                sp_size: 1
+                max_concurrency: 2
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="http://host:port"):
+        load_config(config_path)

--- a/tests/global_scheduler/test_server.py
+++ b/tests/global_scheduler/test_server.py
@@ -1,0 +1,46 @@
+import textwrap
+
+import pytest
+from fastapi.testclient import TestClient
+
+from vllm_omni.global_scheduler.config import load_config
+from vllm_omni.global_scheduler.server import create_app
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+
+def test_health_endpoint_returns_scheduler_and_ok(tmp_path):
+    config_path = tmp_path / "scheduler.yaml"
+    config_path.write_text(
+        textwrap.dedent(
+            """
+            scheduler:
+              type: ondisc_sp1
+            instances:
+              - id: worker-0
+                endpoint: http://127.0.0.1:9001
+                sp_size: 1
+                max_concurrency: 1
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    config = load_config(config_path)
+    app = create_app(config)
+    client = TestClient(app)
+
+    response = client.get("/health")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["status"] == "ok"
+    assert payload["scheduler"] == "ondisc_sp1"
+    assert "version" in payload
+
+
+def test_load_config_missing_file_raises_clear_error(tmp_path):
+    missing = tmp_path / "not_found.yaml"
+
+    with pytest.raises(ValueError, match="Config file not found"):
+        load_config(missing)

--- a/vllm_omni/global_scheduler/__init__.py
+++ b/vllm_omni/global_scheduler/__init__.py
@@ -1,0 +1,4 @@
+from .config import GlobalSchedulerConfig, load_config
+from .server import create_app
+
+__all__ = ["GlobalSchedulerConfig", "create_app", "load_config"]

--- a/vllm_omni/global_scheduler/config.py
+++ b/vllm_omni/global_scheduler/config.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+from pathlib import Path
+from urllib.parse import urlparse
+
+import yaml
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator, model_validator
+
+
+class ServerConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    host: str = "0.0.0.0"
+    port: int = Field(default=8089, ge=1, le=65535)
+    request_timeout_s: int = Field(default=1800, ge=1)
+
+
+class SchedulerConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    type: str = "baseline_sp1"
+    tie_breaker: str = "random"
+    ewma_alpha: float = Field(default=0.2, gt=0.0, le=1.0)
+
+    @field_validator("type")
+    @classmethod
+    def validate_type(cls, value: str) -> str:
+        if value not in {"baseline_sp1", "ondisc_sp1"}:
+            raise ValueError("scheduler.type must be one of: baseline_sp1, ondisc_sp1")
+        return value
+
+    @field_validator("tie_breaker")
+    @classmethod
+    def validate_tie_breaker(cls, value: str) -> str:
+        if value not in {"random", "lexical"}:
+            raise ValueError("scheduler.tie_breaker must be one of: random, lexical")
+        return value
+
+
+class BaselinePolicyConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    mode: str = "ect"
+
+    @field_validator("mode")
+    @classmethod
+    def validate_mode(cls, value: str) -> str:
+        if value not in {"shortest_queue", "ect"}:
+            raise ValueError("policy.baseline_sp1.mode must be one of: shortest_queue, ect")
+        return value
+
+
+class OnDiscPolicyConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    alpha: float = 1.0
+    beta: float = 0.2
+    gamma: float = 1.0
+    delta: float = 0.0
+    epsilon: float = 0.1
+
+
+class PolicyConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    baseline_sp1: BaselinePolicyConfig = Field(default_factory=BaselinePolicyConfig)
+    ondisc_sp1: OnDiscPolicyConfig = Field(default_factory=OnDiscPolicyConfig)
+
+
+class InstanceConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    id: str
+    endpoint: str
+    sp_size: int = 1
+    max_concurrency: int = Field(default=1, ge=1)
+
+    @field_validator("id")
+    @classmethod
+    def validate_id(cls, value: str) -> str:
+        if not value.strip():
+            raise ValueError("instances[].id cannot be empty")
+        return value
+
+    @field_validator("sp_size")
+    @classmethod
+    def validate_sp_size(cls, value: int) -> int:
+        if value != 1:
+            raise ValueError("instances[].sp_size must be 1 in current stage")
+        return value
+
+    @field_validator("endpoint")
+    @classmethod
+    def validate_endpoint(cls, value: str) -> str:
+        parsed = urlparse(value)
+        if parsed.scheme != "http":
+            raise ValueError("instances[].endpoint must be http://host:port")
+        if not parsed.hostname or parsed.port is None:
+            raise ValueError("instances[].endpoint must include host and port")
+        if parsed.path not in {"", "/"}:
+            raise ValueError("instances[].endpoint must not include path")
+        return value.rstrip("/")
+
+
+class GlobalSchedulerConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    server: ServerConfig = Field(default_factory=ServerConfig)
+    scheduler: SchedulerConfig = Field(default_factory=SchedulerConfig)
+    policy: PolicyConfig = Field(default_factory=PolicyConfig)
+    instances: list[InstanceConfig]
+
+    @model_validator(mode="after")
+    def validate_unique_instance_ids(self) -> GlobalSchedulerConfig:
+        instance_ids = [instance.id for instance in self.instances]
+        if len(instance_ids) != len(set(instance_ids)):
+            raise ValueError("instances[].id must be globally unique")
+        return self
+
+
+def load_config(config_path: str | Path) -> GlobalSchedulerConfig:
+    path = Path(config_path)
+    try:
+        payload = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise ValueError(f"Config file not found: {path}") from exc
+    except yaml.YAMLError as exc:
+        raise ValueError(f"Invalid YAML in config file {path}: {exc}") from exc
+
+    if payload is None:
+        raise ValueError(f"Config file is empty: {path}")
+    if not isinstance(payload, dict):
+        raise ValueError(f"Config root must be a mapping in {path}")
+
+    try:
+        return GlobalSchedulerConfig.model_validate(payload)
+    except ValidationError as exc:
+        raise ValueError(f"Invalid global scheduler config in {path}: {exc}") from exc

--- a/vllm_omni/global_scheduler/server.py
+++ b/vllm_omni/global_scheduler/server.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import argparse
+
+import uvicorn
+from fastapi import FastAPI
+from fastapi.responses import JSONResponse
+
+from vllm_omni.version import __version__
+
+from .config import GlobalSchedulerConfig, load_config
+
+
+def create_app(config: GlobalSchedulerConfig) -> FastAPI:
+    app = FastAPI(title="vLLM-Omni Global Scheduler", version=__version__)
+    app.state.global_scheduler_config = config
+
+    @app.get("/health")
+    async def health() -> JSONResponse:
+        return JSONResponse(
+            content={
+                "status": "ok",
+                "scheduler": config.scheduler.type,
+                "version": __version__,
+            }
+        )
+
+    return app
+
+
+def run_server(config_path: str) -> None:
+    config = load_config(config_path)
+    app = create_app(config)
+    uvicorn.run(app, host=config.server.host, port=config.server.port)
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Run vLLM-Omni global scheduler server")
+    parser.add_argument("--config", required=True, help="Path to global scheduler YAML config")
+    return parser
+
+
+def main() -> None:
+    args = build_arg_parser().parse_args()
+    run_server(args.config)
+
+
+if __name__ == "__main__":
+    main()

--- a/vllm_omni/global_scheduler/types.py
+++ b/vllm_omni/global_scheduler/types.py
@@ -1,0 +1,36 @@
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass(slots=True)
+class RequestMeta:
+    request_id: str
+    weight: float = 1.0
+    width: int | None = None
+    height: int | None = None
+    num_frames: int | None = None
+    num_inference_steps: int | None = None
+    extra: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(slots=True)
+class InstanceSpec:
+    id: str
+    endpoint: str
+    sp_size: int = 1
+    max_concurrency: int = 1
+
+
+@dataclass(slots=True)
+class RuntimeStats:
+    queue_len: int = 0
+    inflight: int = 0
+    ewma_service_time_s: float = 1.0
+
+
+@dataclass(slots=True)
+class RouteDecision:
+    instance_id: str
+    endpoint: str
+    reason: str
+    score: float


### PR DESCRIPTION
## Purpose

Implement PR-1 from workplan/global_scheduler_rewrite_playbook.md:
- Add global_scheduler module skeleton.
- Add YAML config loading + schema validation with clear errors.
- Add minimal runnable scheduler HTTP server with GET /health.

This PR intentionally excludes routing policies and proxy forwarding logic.

## Test Plan

- ruff check vllm_omni/global_scheduler tests/global_scheduler
- ruff format --check vllm_omni/global_scheduler tests/global_scheduler
- pytest --noconftest tests/global_scheduler -q

## Test Result

- ruff check: passed
- ruff format --check: passed
- pytest --noconftest tests/global_scheduler -q: passed (5 passed)
