### PR TITLE
refactor(imagegen): split bench runner into bash entry and python core

### DIFF
--- a/profile/imageGen/run_resolution_steps_bench.py
+++ b/profile/imageGen/run_resolution_steps_bench.py
@@ -1,0 +1,690 @@
+#!/usr/bin/env python3
+import argparse
+import csv
+import json
+import os
+import socket
+import signal
+import statistics
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+@dataclass
+class GlobalConfig:
+    model: str
+    host: str
+    port: int
+    ready_path: str
+    request_path: str
+    ready_timeout_sec: int
+    poll_interval_sec: float
+    stop_timeout_sec: int
+    max_gpu_per_case: int
+    log_root: str
+    prompt: str
+    negative_prompt: str
+    num_outputs: int
+    warmup_runs_per_combo: int
+    measured_runs_per_combo: int
+    request_timeout_sec: int
+    inter_run_sleep_sec: float
+    seed_base: int
+    use_fixed_seed: bool
+    resolutions: list[str]
+    step_values: list[int]
+    extra_cli_args: list[str]
+
+
+@dataclass
+class CaseConfig:
+    case_id: str
+    case_name: str
+    enabled: bool
+    sp: int
+    cfg: int
+    tp: int
+    vae_use_slicing: bool
+    vae_use_tiling: bool
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run image generation resolution/steps benchmarks.")
+    parser.add_argument("--config", required=True, help="Path to YAML benchmark config")
+    parser.add_argument("--model", default="", help="Optional model override")
+    return parser.parse_args()
+
+
+def load_yaml(path: str) -> dict[str, Any]:
+    with open(path, "r", encoding="utf-8") as f:
+        return yaml.safe_load(f) or {}
+
+
+def build_global_config(cfg: dict[str, Any], model_override: str) -> GlobalConfig:
+    g = cfg.get("global", {})
+    model = model_override if model_override else str(g.get("model", "Qwen/Qwen-Image"))
+    return GlobalConfig(
+        model=model,
+        host=str(g.get("host", "127.0.0.1")),
+        port=int(g.get("port", 8091)),
+        ready_path=str(g.get("ready_path", "/v1/models")),
+        request_path=str(g.get("request_path", "/v1/images/generations")),
+        ready_timeout_sec=int(g.get("ready_timeout_sec", 600)),
+        poll_interval_sec=float(g.get("poll_interval_sec", 2)),
+        stop_timeout_sec=int(g.get("stop_timeout_sec", 60)),
+        max_gpu_per_case=int(g.get("max_gpu_per_case", 8)),
+        log_root=str(g.get("log_root", "./image_steps_results")),
+        prompt=str(g.get("prompt", "a photo of a cute cat in a garden, ultra detailed")),
+        negative_prompt=str(g.get("negative_prompt", "")),
+        num_outputs=int(g.get("num_outputs", 1)),
+        warmup_runs_per_combo=int(g.get("warmup_runs_per_combo", 1)),
+        measured_runs_per_combo=int(g.get("measured_runs_per_combo", 5)),
+        request_timeout_sec=int(g.get("request_timeout_sec", 1800)),
+        inter_run_sleep_sec=float(g.get("inter_run_sleep_sec", 0)),
+        seed_base=int(g.get("seed_base", 1234)),
+        use_fixed_seed=bool(g.get("use_fixed_seed", False)),
+        resolutions=[str(x) for x in g.get("resolutions", ["512x512", "768x768", "1024x1024"])],
+        step_values=[int(x) for x in g.get("step_values", [5, 10, 50])],
+        extra_cli_args=[str(x) for x in g.get("extra_cli_args", [])],
+    )
+
+
+def parse_cases(cfg: dict[str, Any]) -> list[CaseConfig]:
+    cases = []
+    for case in cfg.get("cases", []):
+        cases.append(
+            CaseConfig(
+                case_id=str(case.get("id", "")),
+                case_name=str(case.get("name", "")),
+                enabled=bool(case.get("enabled", True)),
+                sp=int(case.get("sp", 1)),
+                cfg=int(case.get("cfg", 1)),
+                tp=int(case.get("tp", 1)),
+                vae_use_slicing=bool(case.get("vae_use_slicing", False)),
+                vae_use_tiling=bool(case.get("vae_use_tiling", False)),
+            )
+        )
+    return cases
+
+
+def ensure_summary_csv(path: Path) -> None:
+    if path.exists():
+        return
+    with open(path, "w", newline="", encoding="utf-8") as f:
+        writer = csv.writer(f)
+        writer.writerow(
+            [
+                "case_id",
+                "case_name",
+                "gpu",
+                "sp",
+                "cfg",
+                "tp",
+                "vae_use_slicing",
+                "vae_use_tiling",
+                "resolution",
+                "steps",
+                "first_startup_s",
+                "warmup_runs",
+                "measured_runs",
+                "latency_mean_s",
+                "latency_std_s",
+                "status",
+                "note",
+            ]
+        )
+
+
+def write_summary_row(summary_csv: Path, row: list[Any]) -> None:
+    with open(summary_csv, "a", newline="", encoding="utf-8") as f:
+        csv.writer(f).writerow(row)
+
+
+def append_run_row(run_csv: Path, row: list[Any]) -> None:
+    with open(run_csv, "a", newline="", encoding="utf-8") as f:
+        csv.writer(f).writerow(row)
+
+
+def build_server_cmd(global_cfg: GlobalConfig, case: CaseConfig, run_log: Path) -> list[str]:
+    cmd = [
+        "vllm",
+        "serve",
+        "--model",
+        global_cfg.model,
+        "--omni",
+        "--port",
+        str(global_cfg.port),
+        "--host",
+        global_cfg.host,
+        "--log-file",
+        str(run_log),
+        "--ulysses-degree",
+        str(case.sp),
+        "--cfg-parallel-size",
+        str(case.cfg),
+        "--tensor-parallel-size",
+        str(case.tp),
+    ]
+    if case.vae_use_slicing:
+        cmd.append("--vae-use-slicing")
+    if case.vae_use_tiling:
+        cmd.append("--vae-use-tiling")
+    cmd.extend(global_cfg.extra_cli_args)
+    return cmd
+
+
+def start_server(cmd: list[str], run_log: Path) -> subprocess.Popen[Any]:
+    run_log.parent.mkdir(parents=True, exist_ok=True)
+    log_file = open(run_log, "w", encoding="utf-8")
+    proc = subprocess.Popen(  # noqa: S603
+        cmd,
+        stdout=log_file,
+        stderr=subprocess.STDOUT,
+        start_new_session=True,
+        close_fds=True,
+    )
+    log_file.close()
+    return proc
+
+
+def stop_server(proc: subprocess.Popen[Any] | None, timeout_sec: int) -> None:
+    if proc is None:
+        return
+    if proc.poll() is not None:
+        return
+    try:
+        os.killpg(proc.pid, signal.SIGTERM)
+    except ProcessLookupError:
+        return
+
+    deadline = time.monotonic() + timeout_sec
+    while time.monotonic() < deadline:
+        if proc.poll() is not None:
+            return
+        time.sleep(1)
+
+    try:
+        os.killpg(proc.pid, signal.SIGKILL)
+    except ProcessLookupError:
+        return
+
+
+def wait_ready(url: str, timeout_sec: int, interval_sec: float) -> tuple[bool, float]:
+    start = time.monotonic()
+    while True:
+        try:
+            req = urllib.request.Request(url, method="GET")
+            with urllib.request.urlopen(req, timeout=5) as resp:
+                if resp.status == 200:
+                    return True, time.monotonic() - start
+                code = resp.status
+        except urllib.error.HTTPError as exc:
+            code = exc.code
+        except Exception:
+            code = "NA"
+
+        waited = int(time.monotonic() - start)
+        print(f"  waiting ready: {url} (http={code}, waited={waited}s/{timeout_sec}s)")
+        if time.monotonic() - start >= timeout_sec:
+            return False, 0.0
+        time.sleep(interval_sec)
+
+
+def build_payload(global_cfg: GlobalConfig, size: str, steps: int, seed: int) -> bytes:
+    payload: dict[str, Any] = {
+        "prompt": global_cfg.prompt,
+        "size": size,
+        "n": global_cfg.num_outputs,
+        "num_inference_steps": steps,
+        "seed": seed,
+    }
+    if global_cfg.negative_prompt:
+        payload["negative_prompt"] = global_cfg.negative_prompt
+    return json.dumps(payload, ensure_ascii=True).encode("utf-8")
+
+
+def request_once(endpoint: str, payload: bytes, timeout_sec: int) -> tuple[str, float, str]:
+    start = time.monotonic()
+    req = urllib.request.Request(
+        endpoint,
+        data=payload,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout_sec) as resp:
+            latency = time.monotonic() - start
+            return str(resp.status), latency, ""
+    except urllib.error.HTTPError as exc:
+        latency = time.monotonic() - start
+        return str(exc.code), latency, f"http-{exc.code}"
+    except urllib.error.URLError as exc:
+        latency = time.monotonic() - start
+        if isinstance(exc.reason, TimeoutError | socket.timeout):
+            return "000", latency, "request-timeout"
+        return "000", latency, "request-error"
+    except socket.timeout:
+        latency = time.monotonic() - start
+        return "000", latency, "request-timeout"
+    except TimeoutError:
+        latency = time.monotonic() - start
+        return "000", latency, "request-timeout"
+    except Exception:
+        latency = time.monotonic() - start
+        return "000", latency, "request-error"
+
+
+def sanitize_name(name: str) -> str:
+    return "".join(ch if ch.isalnum() or ch in ("-", "_") else "_" for ch in name)
+
+
+def write_failed_combo_summaries(
+    summary_csv: Path,
+    combos: list[tuple[str, int]],
+    start_idx: int,
+    case: CaseConfig,
+    gpu_count: int,
+    first_startup_s: str,
+    global_cfg: GlobalConfig,
+    note: str,
+    status: str = "FAIL",
+) -> None:
+    for idx in range(start_idx, len(combos)):
+        size, steps = combos[idx]
+        write_summary_row(
+            summary_csv,
+            [
+                case.case_id,
+                case.case_name,
+                gpu_count,
+                case.sp,
+                case.cfg,
+                case.tp,
+                str(case.vae_use_slicing).lower(),
+                str(case.vae_use_tiling).lower(),
+                size,
+                steps,
+                first_startup_s,
+                global_cfg.warmup_runs_per_combo,
+                global_cfg.measured_runs_per_combo,
+                "",
+                "",
+                status,
+                note,
+            ],
+        )
+
+
+def should_abort_case(note: str) -> bool:
+    return note in {"request-timeout", "request-error", "service-exited"}
+
+
+def run_case(summary_csv: Path, run_root: Path, global_cfg: GlobalConfig, case: CaseConfig) -> None:
+    if not case.enabled:
+        return
+
+    combos = [(size, steps) for size in global_cfg.resolutions for steps in global_cfg.step_values]
+    gpu_count = case.sp * case.cfg * case.tp
+
+    if gpu_count > global_cfg.max_gpu_per_case:
+        print(f"[SKIP] case {case.case_id} ({case.case_name}) requires {gpu_count} GPUs (> {global_cfg.max_gpu_per_case})")
+        write_failed_combo_summaries(
+            summary_csv,
+            combos,
+            0,
+            case,
+            gpu_count,
+            "",
+            global_cfg,
+            f"requires>{global_cfg.max_gpu_per_case}gpus",
+            status="SKIP",
+        )
+        return
+
+    case_dir = run_root / f"case_{case.case_id}_{sanitize_name(case.case_name)}"
+    case_dir.mkdir(parents=True, exist_ok=True)
+    run_csv = case_dir / "runs.csv"
+    run_log = case_dir / "service.log"
+
+    with open(run_csv, "w", newline="", encoding="utf-8") as f:
+        writer = csv.writer(f)
+        writer.writerow(
+            [
+                "case_id",
+                "case_name",
+                "gpu",
+                "sp",
+                "cfg",
+                "tp",
+                "vae_use_slicing",
+                "vae_use_tiling",
+                "resolution",
+                "steps",
+                "run_type",
+                "run_idx",
+                "seed",
+                "http_code",
+                "latency_s",
+                "status",
+                "error",
+            ]
+        )
+
+    cmd = build_server_cmd(global_cfg, case, run_log)
+    ready_url = f"http://{global_cfg.host}:{global_cfg.port}{global_cfg.ready_path}"
+    infer_url = f"http://{global_cfg.host}:{global_cfg.port}{global_cfg.request_path}"
+
+    print(f"[CASE {case.case_id}] {case.case_name}")
+    print("  command:", " ".join(cmd))
+    print(f"  ready check: {ready_url}")
+    print(f"  infer endpoint: {infer_url}")
+    print(f"  service log: {run_log}")
+
+    proc: subprocess.Popen[Any] | None = None
+    first_startup_s = ""
+
+    try:
+        proc = start_server(cmd, run_log)
+
+        ready_ok, startup_s = wait_ready(ready_url, global_cfg.ready_timeout_sec, global_cfg.poll_interval_sec)
+        if not ready_ok:
+            print(f"[FAIL] case {case.case_id} startup did not become ready in {global_cfg.ready_timeout_sec}s")
+            write_failed_combo_summaries(
+                summary_csv,
+                combos,
+                0,
+                case,
+                gpu_count,
+                "",
+                global_cfg,
+                "startup-timeout",
+            )
+            return
+
+        first_startup_s = f"{startup_s:.6f}"
+        print(f"  first startup ready in {first_startup_s}s")
+
+        for combo_idx, (size, steps) in enumerate(combos):
+            print(f"  [COMBO] size={size} steps={steps}")
+            combo_csv = case_dir / f"combo_{size}_{steps}.csv"
+            measured_latencies: list[float] = []
+            combo_note = ""
+
+            with open(combo_csv, "w", newline="", encoding="utf-8") as f:
+                csv.writer(f).writerow(["run_idx", "seed", "http_code", "latency_s", "status", "error"])
+
+            for w in range(1, global_cfg.warmup_runs_per_combo + 1):
+                if proc.poll() is not None:
+                    combo_note = "service-exited"
+                    break
+
+                seed = global_cfg.seed_base if global_cfg.use_fixed_seed else (global_cfg.seed_base + w)
+                payload = build_payload(global_cfg, size, steps, seed)
+                http_code, latency_s, err = request_once(infer_url, payload, global_cfg.request_timeout_sec)
+
+                status = "PASS" if http_code == "200" else "FAIL"
+                if status == "FAIL":
+                    combo_note = err or f"warmup-http-{http_code}"
+
+                append_run_row(
+                    run_csv,
+                    [
+                        case.case_id,
+                        case.case_name,
+                        gpu_count,
+                        case.sp,
+                        case.cfg,
+                        case.tp,
+                        str(case.vae_use_slicing).lower(),
+                        str(case.vae_use_tiling).lower(),
+                        size,
+                        steps,
+                        "warmup",
+                        w,
+                        seed,
+                        http_code,
+                        f"{latency_s:.6f}",
+                        status,
+                        combo_note if status == "FAIL" else "",
+                    ],
+                )
+                print(f"    warmup {w}/{global_cfg.warmup_runs_per_combo}: http={http_code} latency={latency_s:.6f}s")
+
+                if status == "FAIL":
+                    break
+                if global_cfg.inter_run_sleep_sec > 0:
+                    time.sleep(global_cfg.inter_run_sleep_sec)
+
+            if combo_note:
+                if should_abort_case(combo_note):
+                    write_failed_combo_summaries(
+                        summary_csv,
+                        combos,
+                        combo_idx,
+                        case,
+                        gpu_count,
+                        first_startup_s,
+                        global_cfg,
+                        f"case-aborted:{combo_note}",
+                    )
+                    print(f"  [ABORT] case {case.case_id} due to {combo_note}, moving to next case")
+                    return
+
+                write_summary_row(
+                    summary_csv,
+                    [
+                        case.case_id,
+                        case.case_name,
+                        gpu_count,
+                        case.sp,
+                        case.cfg,
+                        case.tp,
+                        str(case.vae_use_slicing).lower(),
+                        str(case.vae_use_tiling).lower(),
+                        size,
+                        steps,
+                        first_startup_s,
+                        global_cfg.warmup_runs_per_combo,
+                        global_cfg.measured_runs_per_combo,
+                        "",
+                        "",
+                        "FAIL",
+                        combo_note,
+                    ],
+                )
+                continue
+
+            for run_idx in range(1, global_cfg.measured_runs_per_combo + 1):
+                if proc.poll() is not None:
+                    combo_note = "service-exited"
+                    break
+
+                seed = (
+                    global_cfg.seed_base
+                    if global_cfg.use_fixed_seed
+                    else (global_cfg.seed_base + global_cfg.warmup_runs_per_combo + run_idx)
+                )
+                payload = build_payload(global_cfg, size, steps, seed)
+                http_code, latency_s, err = request_once(infer_url, payload, global_cfg.request_timeout_sec)
+                status = "PASS" if http_code == "200" else "FAIL"
+                if status == "FAIL":
+                    combo_note = err or f"http-{http_code}"
+
+                with open(combo_csv, "a", newline="", encoding="utf-8") as f:
+                    csv.writer(f).writerow(
+                        [
+                            run_idx,
+                            seed,
+                            http_code,
+                            f"{latency_s:.6f}",
+                            status,
+                            combo_note if status == "FAIL" else "",
+                        ]
+                    )
+
+                append_run_row(
+                    run_csv,
+                    [
+                        case.case_id,
+                        case.case_name,
+                        gpu_count,
+                        case.sp,
+                        case.cfg,
+                        case.tp,
+                        str(case.vae_use_slicing).lower(),
+                        str(case.vae_use_tiling).lower(),
+                        size,
+                        steps,
+                        "measure",
+                        run_idx,
+                        seed,
+                        http_code,
+                        f"{latency_s:.6f}",
+                        status,
+                        combo_note if status == "FAIL" else "",
+                    ],
+                )
+                print(
+                    f"    measure {run_idx}/{global_cfg.measured_runs_per_combo}: "
+                    f"http={http_code} latency={latency_s:.6f}s"
+                )
+
+                if status == "FAIL":
+                    break
+                measured_latencies.append(latency_s)
+                if global_cfg.inter_run_sleep_sec > 0:
+                    time.sleep(global_cfg.inter_run_sleep_sec)
+
+            if combo_note:
+                if should_abort_case(combo_note):
+                    write_failed_combo_summaries(
+                        summary_csv,
+                        combos,
+                        combo_idx,
+                        case,
+                        gpu_count,
+                        first_startup_s,
+                        global_cfg,
+                        f"case-aborted:{combo_note}",
+                    )
+                    print(f"  [ABORT] case {case.case_id} due to {combo_note}, moving to next case")
+                    return
+
+                write_summary_row(
+                    summary_csv,
+                    [
+                        case.case_id,
+                        case.case_name,
+                        gpu_count,
+                        case.sp,
+                        case.cfg,
+                        case.tp,
+                        str(case.vae_use_slicing).lower(),
+                        str(case.vae_use_tiling).lower(),
+                        size,
+                        steps,
+                        first_startup_s,
+                        global_cfg.warmup_runs_per_combo,
+                        global_cfg.measured_runs_per_combo,
+                        "",
+                        "",
+                        "FAIL",
+                        combo_note,
+                    ],
+                )
+                continue
+
+            if not measured_latencies:
+                write_summary_row(
+                    summary_csv,
+                    [
+                        case.case_id,
+                        case.case_name,
+                        gpu_count,
+                        case.sp,
+                        case.cfg,
+                        case.tp,
+                        str(case.vae_use_slicing).lower(),
+                        str(case.vae_use_tiling).lower(),
+                        size,
+                        steps,
+                        first_startup_s,
+                        global_cfg.warmup_runs_per_combo,
+                        global_cfg.measured_runs_per_combo,
+                        "",
+                        "",
+                        "FAIL",
+                        "no-measured-results",
+                    ],
+                )
+                continue
+
+            mean_s = statistics.mean(measured_latencies)
+            std_s = statistics.stdev(measured_latencies) if len(measured_latencies) > 1 else 0.0
+            write_summary_row(
+                summary_csv,
+                [
+                    case.case_id,
+                    case.case_name,
+                    gpu_count,
+                    case.sp,
+                    case.cfg,
+                    case.tp,
+                    str(case.vae_use_slicing).lower(),
+                    str(case.vae_use_tiling).lower(),
+                    size,
+                    steps,
+                    first_startup_s,
+                    global_cfg.warmup_runs_per_combo,
+                    global_cfg.measured_runs_per_combo,
+                    f"{mean_s:.6f}",
+                    f"{std_s:.6f}",
+                    "PASS",
+                    "",
+                ],
+            )
+            print(f"  [PASS] size={size} steps={steps} mean={mean_s:.6f}s std={std_s:.6f}s")
+
+        print(f"[CASE {case.case_id}] done")
+    finally:
+        # Forcefully recycle process group to avoid a hung case blocking later cases.
+        stop_server(proc, global_cfg.stop_timeout_sec)
+
+
+def main() -> int:
+    args = parse_args()
+    cfg_path = Path(args.config).resolve()
+    if not cfg_path.is_file():
+        print(f"Config file not found: {cfg_path}", file=sys.stderr)
+        return 1
+
+    cfg = load_yaml(str(cfg_path))
+    global_cfg = build_global_config(cfg, args.model)
+
+    if args.model:
+        print(f"Using model override: {global_cfg.model}")
+
+    script_dir = Path(__file__).resolve().parent
+    run_root = (script_dir / global_cfg.log_root).resolve()
+    run_root.mkdir(parents=True, exist_ok=True)
+
+    summary_csv = run_root / "summary.csv"
+    ensure_summary_csv(summary_csv)
+
+    for case in parse_cases(cfg):
+        run_case(summary_csv, run_root, global_cfg, case)
+
+    print(f"Done. summary: {summary_csv}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/profile/imageGen/run_resolution_steps_bench.sh
+++ b/profile/imageGen/run_resolution_steps_bench.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 DEFAULT_CONFIG="${SCRIPT_DIR}/resolution_steps_bench_cases.yaml"
+PY_RUNNER="${SCRIPT_DIR}/run_resolution_steps_bench.py"
 CONFIG_PATH="${DEFAULT_CONFIG}"
 MODEL_OVERRIDE=""
 
@@ -14,10 +15,18 @@ print_usage() {
 while (( $# > 0 )); do
   case "$1" in
     --config)
+      if (( $# < 2 )); then
+        echo "--config requires a value" >&2
+        exit 1
+      fi
       CONFIG_PATH="$2"
       shift 2
       ;;
     --model)
+      if (( $# < 2 )); then
+        echo "--model requires a value" >&2
+        exit 1
+      fi
       MODEL_OVERRIDE="$2"
       shift 2
       ;;
@@ -45,13 +54,13 @@ if [[ ! -f "${CONFIG_PATH}" ]]; then
   exit 1
 fi
 
-if ! command -v python >/dev/null 2>&1; then
-  echo "python is required to parse yaml config." >&2
+if [[ ! -f "${PY_RUNNER}" ]]; then
+  echo "Python runner not found: ${PY_RUNNER}" >&2
   exit 1
 fi
 
-if ! command -v curl >/dev/null 2>&1; then
-  echo "curl is required for readiness checks and requests." >&2
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "python3 is required." >&2
   exit 1
 fi
 
@@ -60,417 +69,14 @@ if ! command -v vllm >/dev/null 2>&1; then
   exit 1
 fi
 
-if ! python -c "import yaml" >/dev/null 2>&1; then
+if ! python3 -c "import yaml" >/dev/null 2>&1; then
   echo "PyYAML is required. Install with: pip install pyyaml" >&2
   exit 1
 fi
 
-readarray -t GLOBAL_VARS < <(
-  python - "${CONFIG_PATH}" "${MODEL_OVERRIDE}" <<'PY'
-import json
-import shlex
-import sys
-import yaml
-
-cfg = yaml.safe_load(open(sys.argv[1], "r", encoding="utf-8"))
-g = cfg.get("global", {})
-model_override = sys.argv[2] if len(sys.argv) > 2 else ""
-model = model_override if model_override else str(g.get("model", "Qwen/Qwen-Image"))
-
-print(f"MODEL={shlex.quote(model)}")
-print(f"HOST={shlex.quote(str(g.get('host', '127.0.0.1')))}")
-print(f"PORT={int(g.get('port', 8091))}")
-print(f"READY_PATH={shlex.quote(str(g.get('ready_path', '/v1/models')))}")
-print(f"REQUEST_PATH={shlex.quote(str(g.get('request_path', '/v1/images/generations')))}")
-print(f"READY_TIMEOUT_SEC={int(g.get('ready_timeout_sec', 600))}")
-print(f"POLL_INTERVAL_SEC={int(g.get('poll_interval_sec', 2))}")
-print(f"STOP_TIMEOUT_SEC={int(g.get('stop_timeout_sec', 60))}")
-print(f"MAX_GPU_PER_CASE={int(g.get('max_gpu_per_case', 8))}")
-print(f"LOG_ROOT={shlex.quote(str(g.get('log_root', './image_steps_results')))}")
-print(f"PROMPT={shlex.quote(str(g.get('prompt', 'a photo of a cute cat in a garden, ultra detailed')))}")
-print(f"NEGATIVE_PROMPT={shlex.quote(str(g.get('negative_prompt', '')))}")
-print(f"NUM_OUTPUTS={int(g.get('num_outputs', 1))}")
-print(f"WARMUP_RUNS_PER_COMBO={int(g.get('warmup_runs_per_combo', 1))}")
-print(f"MEASURED_RUNS_PER_COMBO={int(g.get('measured_runs_per_combo', 5))}")
-print(f"REQUEST_TIMEOUT_SEC={int(g.get('request_timeout_sec', 1800))}")
-print(f"INTER_RUN_SLEEP_SEC={float(g.get('inter_run_sleep_sec', 0))}")
-print(f"SEED_BASE={int(g.get('seed_base', 1234))}")
-print(f"USE_FIXED_SEED={str(bool(g.get('use_fixed_seed', False))).lower()}")
-print("RESOLUTIONS_JSON=" + shlex.quote(json.dumps(g.get("resolutions", ["512x512", "768x768", "1024x1024"]))))
-print("STEP_VALUES_JSON=" + shlex.quote(json.dumps(g.get("step_values", [5, 10, 50]))))
-print("EXTRA_CLI_ARGS_JSON=" + shlex.quote(json.dumps(g.get("extra_cli_args", []))))
-PY
-)
-
-for kv in "${GLOBAL_VARS[@]}"; do
-  eval "${kv}"
-done
-
+CMD=(python3 "${PY_RUNNER}" --config "${CONFIG_PATH}")
 if [[ -n "${MODEL_OVERRIDE}" ]]; then
-  echo "Using model override: ${MODEL}"
+  CMD+=(--model "${MODEL_OVERRIDE}")
 fi
 
-RUN_ROOT="${SCRIPT_DIR}/${LOG_ROOT}"
-mkdir -p "${RUN_ROOT}"
-
-SUMMARY_CSV="${RUN_ROOT}/summary.csv"
-if [[ ! -f "${SUMMARY_CSV}" ]]; then
-  echo "case_id,case_name,gpu,sp,cfg,tp,vae_use_slicing,vae_use_tiling,resolution,steps,first_startup_s,warmup_runs,measured_runs,latency_mean_s,latency_std_s,status,note" > "${SUMMARY_CSV}"
-fi
-
-cleanup_server() {
-  local pid="$1"
-  local timeout_sec="$2"
-
-  if kill -0 "${pid}" >/dev/null 2>&1; then
-    kill -TERM "${pid}" >/dev/null 2>&1 || true
-    local elapsed=0
-    while kill -0 "${pid}" >/dev/null 2>&1; do
-      sleep 1
-      elapsed=$((elapsed + 1))
-      if (( elapsed >= timeout_sec )); then
-        kill -KILL "${pid}" >/dev/null 2>&1 || true
-        break
-      fi
-    done
-  fi
-}
-
-wait_ready() {
-  local url="$1"
-  local timeout_sec="$2"
-  local interval_sec="$3"
-  local start_ns
-  start_ns="$(date +%s%N)"
-  local waited=0
-
-  while true; do
-    local code
-    code="$(curl -s -o /dev/null -w '%{http_code}' "${url}" || true)"
-    if [[ "${code}" == "200" ]]; then
-      local end_ns
-      end_ns="$(date +%s%N)"
-      python - <<PY
-start_ns=${start_ns}
-end_ns=${end_ns}
-print((end_ns - start_ns) / 1e9)
-PY
-      return 0
-    fi
-
-    echo "  waiting ready: ${url} (http=${code:-NA}, waited=${waited}s/${timeout_sec}s)"
-
-    sleep "${interval_sec}"
-    waited=$((waited + interval_sec))
-    if (( waited >= timeout_sec )); then
-      return 1
-    fi
-  done
-}
-
-build_cmd_line() {
-  local model="$1"
-  local port="$2"
-  local host="$3"
-  local log_file="$4"
-  local sp="$5"
-  local cfg="$6"
-  local tp="$7"
-  local vae_use_slicing="$8"
-  local vae_use_tiling="$9"
-  local extra_cli_json="${10}"
-
-  local cmd=(vllm serve --model "${model}" --omni --port "${port}" --host "${host}" --log-file "${log_file}" --ulysses-degree "${sp}" --cfg-parallel-size "${cfg}" --tensor-parallel-size "${tp}")
-
-  if [[ "${vae_use_slicing}" == "true" ]]; then
-    cmd+=(--vae-use-slicing)
-  fi
-  if [[ "${vae_use_tiling}" == "true" ]]; then
-    cmd+=(--vae-use-tiling)
-  fi
-
-  mapfile -t extra_args < <(
-    python - "${extra_cli_json}" <<'PY'
-import json
-import sys
-for item in json.loads(sys.argv[1]):
-    print(str(item))
-PY
-  )
-
-  if (( ${#extra_args[@]} > 0 )); then
-    cmd+=("${extra_args[@]}")
-  fi
-
-  printf '%q ' "${cmd[@]}"
-  echo
-}
-
-start_server() {
-  local cmd_line="$1"
-  local run_log="$2"
-  local clear_log="$3"
-
-  if [[ "${clear_log}" == "true" ]]; then
-    : > "${run_log}"
-  fi
-
-  eval "${cmd_line}" >> "${run_log}" 2>&1 &
-  echo "$!"
-}
-
-request_once() {
-  local endpoint="$1"
-  local payload_json="$2"
-  local timeout_sec="$3"
-
-  local result
-  result="$(curl -sS -X POST "${endpoint}" \
-    -H 'Content-Type: application/json' \
-    --max-time "${timeout_sec}" \
-    --data "${payload_json}" \
-    -o /dev/null \
-    -w '%{http_code},%{time_total}' || true)"
-
-  if [[ -z "${result}" ]]; then
-    echo "000,0"
-  else
-    echo "${result}"
-  fi
-}
-
-build_payload_json() {
-  local prompt="$1"
-  local negative_prompt="$2"
-  local size="$3"
-  local steps="$4"
-  local seed="$5"
-  local outputs="$6"
-
-  python - "${prompt}" "${negative_prompt}" "${size}" "${steps}" "${seed}" "${outputs}" <<'PY'
-import json
-import sys
-
-prompt = sys.argv[1]
-negative_prompt = sys.argv[2]
-size = sys.argv[3]
-steps = int(sys.argv[4])
-seed = int(sys.argv[5])
-outputs = int(sys.argv[6])
-
-payload = {
-    "prompt": prompt,
-    "size": size,
-    "n": outputs,
-    "num_inference_steps": steps,
-    "seed": seed,
-}
-if negative_prompt:
-    payload["negative_prompt"] = negative_prompt
-
-print(json.dumps(payload, ensure_ascii=True))
-PY
-}
-
-calc_latency_stats() {
-  local csv_path="$1"
-  python - "${csv_path}" <<'PY'
-import csv
-import statistics
-import sys
-
-vals = []
-with open(sys.argv[1], newline="", encoding="utf-8") as f:
-    reader = csv.DictReader(f)
-    for row in reader:
-        if row.get("status") == "PASS":
-            vals.append(float(row["latency_s"]))
-
-if not vals:
-    print("NA,NA")
-elif len(vals) == 1:
-    print(f"{vals[0]},0.0")
-else:
-    print(f"{statistics.mean(vals)},{statistics.stdev(vals)}")
-PY
-}
-
-readarray -t CASE_ROWS < <(
-  python - "${CONFIG_PATH}" <<'PY'
-import sys
-import yaml
-
-cfg = yaml.safe_load(open(sys.argv[1], "r", encoding="utf-8"))
-for case in cfg.get("cases", []):
-    print("\t".join([
-        str(case.get("id", "")),
-        str(case.get("name", "")),
-        str(bool(case.get("enabled", True))).lower(),
-        str(int(case.get("sp", 1))),
-        str(int(case.get("cfg", 1))),
-        str(int(case.get("tp", 1))),
-        str(bool(case.get("vae_use_slicing", False))).lower(),
-        str(bool(case.get("vae_use_tiling", False))).lower(),
-    ]))
-PY
-)
-
-readarray -t RESOLUTION_ROWS < <(
-  python - "${RESOLUTIONS_JSON}" <<'PY'
-import json
-import sys
-for item in json.loads(sys.argv[1]):
-    print(str(item))
-PY
-)
-
-readarray -t STEP_ROWS < <(
-  python - "${STEP_VALUES_JSON}" <<'PY'
-import json
-import sys
-for item in json.loads(sys.argv[1]):
-    print(int(item))
-PY
-)
-
-for row in "${CASE_ROWS[@]}"; do
-  IFS=$'\t' read -r case_id case_name enabled sp cfg tp vae_use_slicing vae_use_tiling <<<"${row}"
-
-  if [[ "${enabled}" != "true" ]]; then
-    continue
-  fi
-
-  gpu_count=$((sp * cfg * tp))
-  if (( gpu_count > MAX_GPU_PER_CASE )); then
-    echo "[SKIP] case ${case_id} (${case_name}) requires ${gpu_count} GPUs (> ${MAX_GPU_PER_CASE})"
-    for size in "${RESOLUTION_ROWS[@]}"; do
-      for steps in "${STEP_ROWS[@]}"; do
-        echo "${case_id},${case_name},${gpu_count},${sp},${cfg},${tp},${vae_use_slicing},${vae_use_tiling},${size},${steps},,,${MEASURED_RUNS_PER_COMBO},,,SKIP,requires>${MAX_GPU_PER_CASE}gpus" >> "${SUMMARY_CSV}"
-      done
-    done
-    continue
-  fi
-
-  case_dir="${RUN_ROOT}/case_${case_id}_${case_name}"
-  mkdir -p "${case_dir}"
-  run_csv="${case_dir}/runs.csv"
-  run_log="${case_dir}/service.log"
-
-  echo "case_id,case_name,gpu,sp,cfg,tp,vae_use_slicing,vae_use_tiling,resolution,steps,run_type,run_idx,seed,http_code,latency_s,status,error" > "${run_csv}"
-
-  cmd_line="$(build_cmd_line "${MODEL}" "${PORT}" "${HOST}" "${run_log}" "${sp}" "${cfg}" "${tp}" "${vae_use_slicing}" "${vae_use_tiling}" "${EXTRA_CLI_ARGS_JSON}")"
-  ready_url="http://${HOST}:${PORT}${READY_PATH}"
-  infer_url="http://${HOST}:${PORT}${REQUEST_PATH}"
-
-  echo "[CASE ${case_id}] ${case_name}"
-  echo "  command: ${cmd_line}"
-  echo "  ready check: ${ready_url}"
-  echo "  infer endpoint: ${infer_url}"
-  echo "  service log: ${run_log}"
-
-  server_pid="$(start_server "${cmd_line}" "${run_log}" "true")"
-
-  first_startup_s=""
-  if ! first_startup_s="$(wait_ready "${ready_url}" "${READY_TIMEOUT_SEC}" "${POLL_INTERVAL_SEC}")"; then
-    echo "[FAIL] case ${case_id} startup did not become ready in ${READY_TIMEOUT_SEC}s"
-    cleanup_server "${server_pid}" "${STOP_TIMEOUT_SEC}" || true
-    for size in "${RESOLUTION_ROWS[@]}"; do
-      for steps in "${STEP_ROWS[@]}"; do
-        echo "${case_id},${case_name},${gpu_count},${sp},${cfg},${tp},${vae_use_slicing},${vae_use_tiling},${size},${steps},,,${MEASURED_RUNS_PER_COMBO},,,FAIL,startup-timeout" >> "${SUMMARY_CSV}"
-      done
-    done
-    continue
-  fi
-
-  echo "  first startup ready in ${first_startup_s}s"
-
-  for size in "${RESOLUTION_ROWS[@]}"; do
-    for steps in "${STEP_ROWS[@]}"; do
-      echo "  [COMBO] size=${size} steps=${steps}"
-
-      combo_failed=false
-      combo_note=""
-
-      for ((w = 1; w <= WARMUP_RUNS_PER_COMBO; w++)); do
-        if [[ "${USE_FIXED_SEED}" == "true" ]]; then
-          seed="${SEED_BASE}"
-        else
-          seed=$((SEED_BASE + w))
-        fi
-        payload_json="$(build_payload_json "${PROMPT}" "${NEGATIVE_PROMPT}" "${size}" "${steps}" "${seed}" "${NUM_OUTPUTS}")"
-        result="$(request_once "${infer_url}" "${payload_json}" "${REQUEST_TIMEOUT_SEC}")"
-        IFS=',' read -r http_code latency_s <<<"${result}"
-
-        status="PASS"
-        err=""
-        if [[ "${http_code}" != "200" ]]; then
-          status="FAIL"
-          err="warmup-http-${http_code}"
-          combo_failed=true
-          combo_note="${err}"
-        fi
-
-        echo "${case_id},${case_name},${gpu_count},${sp},${cfg},${tp},${vae_use_slicing},${vae_use_tiling},${size},${steps},warmup,${w},${seed},${http_code},${latency_s},${status},${err}" >> "${run_csv}"
-        echo "    warmup ${w}/${WARMUP_RUNS_PER_COMBO}: http=${http_code} latency=${latency_s}s"
-
-        if [[ "${combo_failed}" == "true" ]]; then
-          break
-        fi
-        sleep "${INTER_RUN_SLEEP_SEC}"
-      done
-
-      if [[ "${combo_failed}" == "true" ]]; then
-        echo "${case_id},${case_name},${gpu_count},${sp},${cfg},${tp},${vae_use_slicing},${vae_use_tiling},${size},${steps},${first_startup_s},${WARMUP_RUNS_PER_COMBO},${MEASURED_RUNS_PER_COMBO},,,FAIL,${combo_note}" >> "${SUMMARY_CSV}"
-        continue
-      fi
-
-      combo_csv="${case_dir}/combo_${size}_${steps}.csv"
-      echo "run_idx,seed,http_code,latency_s,status,error" > "${combo_csv}"
-
-      for ((run_idx = 1; run_idx <= MEASURED_RUNS_PER_COMBO; run_idx++)); do
-        if [[ "${USE_FIXED_SEED}" == "true" ]]; then
-          seed="${SEED_BASE}"
-        else
-          seed=$((SEED_BASE + WARMUP_RUNS_PER_COMBO + run_idx))
-        fi
-
-        payload_json="$(build_payload_json "${PROMPT}" "${NEGATIVE_PROMPT}" "${size}" "${steps}" "${seed}" "${NUM_OUTPUTS}")"
-        result="$(request_once "${infer_url}" "${payload_json}" "${REQUEST_TIMEOUT_SEC}")"
-        IFS=',' read -r http_code latency_s <<<"${result}"
-
-        status="PASS"
-        err=""
-        if [[ "${http_code}" != "200" ]]; then
-          status="FAIL"
-          err="http-${http_code}"
-          combo_failed=true
-          combo_note="${err}"
-        fi
-
-        echo "${run_idx},${seed},${http_code},${latency_s},${status},${err}" >> "${combo_csv}"
-        echo "${case_id},${case_name},${gpu_count},${sp},${cfg},${tp},${vae_use_slicing},${vae_use_tiling},${size},${steps},measure,${run_idx},${seed},${http_code},${latency_s},${status},${err}" >> "${run_csv}"
-        echo "    measure ${run_idx}/${MEASURED_RUNS_PER_COMBO}: http=${http_code} latency=${latency_s}s"
-
-        if [[ "${combo_failed}" == "true" ]]; then
-          break
-        fi
-        sleep "${INTER_RUN_SLEEP_SEC}"
-      done
-
-      if [[ "${combo_failed}" == "true" ]]; then
-        echo "${case_id},${case_name},${gpu_count},${sp},${cfg},${tp},${vae_use_slicing},${vae_use_tiling},${size},${steps},${first_startup_s},${WARMUP_RUNS_PER_COMBO},${MEASURED_RUNS_PER_COMBO},,,FAIL,${combo_note}" >> "${SUMMARY_CSV}"
-        continue
-      fi
-
-      stats="$(calc_latency_stats "${combo_csv}")"
-      IFS=',' read -r latency_mean latency_std <<<"${stats}"
-      echo "${case_id},${case_name},${gpu_count},${sp},${cfg},${tp},${vae_use_slicing},${vae_use_tiling},${size},${steps},${first_startup_s},${WARMUP_RUNS_PER_COMBO},${MEASURED_RUNS_PER_COMBO},${latency_mean},${latency_std},PASS," >> "${SUMMARY_CSV}"
-      echo "  [PASS] size=${size} steps=${steps} mean=${latency_mean}s std=${latency_std}s"
-    done
-  done
-
-  cleanup_server "${server_pid}" "${STOP_TIMEOUT_SEC}" || true
-  echo "[CASE ${case_id}] done"
-done
-
-echo "Done. summary: ${SUMMARY_CSV}"
+exec "${CMD[@]}"


### PR DESCRIPTION
## Purpose
- split run_resolution_steps_bench.sh into a thin bash entrypoint and a python core runner
- improve robustness when profiling gets stuck

## Changes
- keep bash script responsible only for argument parsing, dependency checks, and invoking python
- move benchmark execution logic to profile/imageGen/run_resolution_steps_bench.py
- add stronger lifecycle management: terminate and force-kill hung service process groups, then continue next case

## Test Plan
- bash -n profile/imageGen/run_resolution_steps_bench.sh
- python3 -m py_compile profile/imageGen/run_resolution_steps_bench.py

## Test Result
- both checks passed locally
